### PR TITLE
Adding logic so that we get basic Open Street map tiles.

### DIFF
--- a/app/modules/predictor/views/mapView.js
+++ b/app/modules/predictor/views/mapView.js
@@ -26,21 +26,21 @@ App.module("Predictor", function(Mod, App, Backbone, Marionette, $, _) {
 
 		onShow: function() {
 			// TODO Map attribution
-			var mapLayer = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.jpg',{
-				attribution: 'Map data &copy; OpenStreetMap, Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="http://developer.mapquest.com/content/osm/mq_logo.png">',
-				maxZoom: 18,
-				subdomains: '1234'
-			});
-			var satLayer = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.jpg',{
-				attribution: '<br/>Portions Courtesy NASA/JPL-Caltech and U.S. Depart. of Agriculture, Farm Service Agency',
-				maxZoom: 18,
-				subdomains: '1234'
-			});
-			var hybLayer = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/hyb/{z}/{x}/{y}.jpg',{
-				attribution: 'Map data &copy; OpenStreetMap, Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="http://developer.mapquest.com/content/osm/mq_logo.png">',
-				maxZoom: 18,
-				subdomains: '1234'
-			});
+            var mapLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{
+                attribution: 'Map data &copy; OpenStreetMap, Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="http://developer.mapquest.com/content/osm/mq_logo.png">',
+                maxZoom: 18,
+                subdomains: ['a','b','c']
+            });
+            var satLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{
+                attribution: 'Map data &copy; OpenStreetMap, Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="http://developer.mapquest.com/content/osm/mq_logo.png">',
+                maxZoom: 18,
+                subdomains: ['a','b','c']
+            });
+            var hybLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{
+                attribution: 'Map data &copy; OpenStreetMap, Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="http://developer.mapquest.com/content/osm/mq_logo.png">',
+                maxZoom: 18,
+                subdomains: ['a','b','c']
+            });
 			var hybGroup = L.layerGroup([satLayer, hybLayer]);
 			var baseMaps = {
 				"Map": mapLayer,


### PR DESCRIPTION
There are currently multiple layers for the Leaflet tiles for the map application.

To get a minimum viable product running lets remove the reference to the old tile service that was on mqcdn.com and replace with openstreetmap.org which is a free service.

Making this change means that we have basic Open Street map but we do NOT have a Satellite layer and we do NOT have a hybrid layer.